### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/Seafarerorg/520e268f-63b0-4333-9167-1a776378f67e/272b6e8d-93f3-40a9-b460-4ac928b6af0d/_apis/work/boardbadge/82d07977-7c8b-40ee-b6ed-3ad2a91b33e2)](https://dev.azure.com/Seafarerorg/520e268f-63b0-4333-9167-1a776378f67e/_boards/board/t/272b6e8d-93f3-40a9-b460-4ac928b6af0d/Microsoft.RequirementCategory)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 [![Board Status](https://dev.azure.com/Seafarerorg/520e268f-63b0-4333-9167-1a776378f67e/272b6e8d-93f3-40a9-b460-4ac928b6af0d/_apis/work/boardbadge/82d07977-7c8b-40ee-b6ed-3ad2a91b33e2)](https://dev.azure.com/Seafarerorg/520e268f-63b0-4333-9167-1a776378f67e/_boards/board/t/272b6e8d-93f3-40a9-b460-4ac928b6af0d/Microsoft.RequirementCategory)
+
+
+Testing is miserable


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Seafarerorg/520e268f-63b0-4333-9167-1a776378f67e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.